### PR TITLE
Add in additional exports

### DIFF
--- a/scripts/generateIcons.ts
+++ b/scripts/generateIcons.ts
@@ -63,6 +63,6 @@ ${Object.entries(icons).map(([iconName]) => `test('${iconName} renders without e
 writeFileSync(`src/icons.test.tsx`, testFile);
 
 // generate barrel file
-const barrelExports = Object.entries(icons).map(([iconName]) => `export {default as ${iconName}} from './icons/${toKebabCase(iconName)}';`).join("\n");
+const barrelExports = Object.entries(icons).map(([iconName]) => `export {default as ${iconName}, default as ${iconName}Icon} from './icons/${toKebabCase(iconName)}';`).join("\n");
 
 writeFileSync(`src/index.ts`, barrelExports);


### PR DESCRIPTION
Adds in additional named exports with the -`Icon` suffix. This makes it easier to import icons with common names that might conflict with other common component names, such as `<Box/>` or `<Badge/>`.

### Before:
```ts
import { ArrowLeft } from 'lucide-mui'
```

### After:
```ts
import { ArrowLeft } from 'lucide-mui'
```
OR
```ts
import { ArrowLeftIcon } from 'lucide-mui'
```